### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 MCP plugin to control Android devices via ADB for automation, testing, and agent integration.
 
+<a href="https://glama.ai/mcp/servers/@TiagoDanin/Android-Debug-Bridge-MCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@TiagoDanin/Android-Debug-Bridge-MCP/badge" alt="Android Debug Bridge MCP server" />
+</a>
+
 ## Features
 
 This MCP server provides tools to:


### PR DESCRIPTION
This PR adds a badge for the [Android Debug Bridge MCP](https://glama.ai/mcp/servers/@TiagoDanin/Android-Debug-Bridge-MCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@TiagoDanin/Android-Debug-Bridge-MCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@TiagoDanin/Android-Debug-Bridge-MCP/badge" alt="Android Debug Bridge MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.